### PR TITLE
Add DriverName to LLM data sent by GridRaceAssistant

### DIFF
--- a/Sources/Assistants/Libraries/RaceAssistant.ahk
+++ b/Sources/Assistants/Libraries/RaceAssistant.ahk
@@ -3276,6 +3276,8 @@ class GridRaceAssistant extends RaceAssistant {
 
 			try {
 				carData := Map("Nr", this.getNr(car)
+							 , "DriverName", driverName(knowledgeBase.getValue("Car." . car . ".Driver.Forname"), knowledgeBase.getValue("Car." . car . ".Driver.Surname")
+												, knowledgeBase.getValue("Car." . car . ".Driver.Nickname"))
 							 , "Class", this.getClass(car)
 							 , "Laps", knowledgeBase.getValue("Car." . car . ".Laps", knowledgeBase.getValue("Car." . car . ".Lap", 0))
 							 , "OverallPosition", this.getPosition(car, "Overall")


### PR DESCRIPTION
Add driver name to LLM data sent by the spotter. This is interesting to be able to ask the spotter about the position of an specific driver, or any other name-related questions.