### PR TITLE
Add PMR UDP Connector

### DIFF
--- a/Sources/Special/PMR UDP Connector/PMR UDP Connector/PMR UDP Connector.csproj
+++ b/Sources/Special/PMR UDP Connector/PMR UDP Connector/PMR UDP Connector.csproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{B8F2A9D3-7E4C-4D1B-9A2F-8C5D6E7F8A9B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PMR_UDP_Connector</RootNamespace>
+    <AssemblyName>PMR UDP Connector</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\..\Binaries\Connectors\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\..\Binaries\Connectors\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="PMRUDPConnector.cs" />
+    <Compile Include="PMRUDPProtocol.cs" />
+    <Compile Include="PMRUDPReceiver.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Sources/Special/PMR UDP Connector/PMR UDP Connector/PMRUDPConnector.cs
+++ b/Sources/Special/PMR UDP Connector/PMR UDP Connector/PMRUDPConnector.cs
@@ -1,0 +1,297 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+namespace PMR_UDP_Connector
+{
+    public class PMRUDPConnector
+    {
+        private PMRUDPReceiver receiver;
+        private readonly CultureInfo enUS = new CultureInfo("en-US");
+
+        public PMRUDPConnector()
+        {
+        }
+
+        public bool Open()
+        {
+            try
+            {
+                if (receiver != null)
+                    receiver.Stop();
+
+                receiver = new PMRUDPReceiver();
+                return receiver.Start();
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public void Close()
+        {
+            try
+            {
+                receiver?.Stop();
+                receiver = null;
+            }
+            catch
+            {
+            }
+        }
+
+        public string Call(string request)
+        {
+            try
+            {
+                if (receiver == null)
+                {
+                    if (!Open())
+                        return "[Session Data]\nActive=false\n";
+                }
+
+                bool writeStandings = request != null && request.Contains("Standings");
+                return writeStandings ? GenerateStandings() : GenerateTelemetry();
+            }
+            catch
+            {
+                return "[Session Data]\nActive=false\n";
+            }
+        }
+
+        private string GenerateTelemetry()
+        {
+            var sb = new StringBuilder();
+            var raceInfo = receiver.GetRaceInfo();
+            var playerState = receiver.GetPlayerState();
+            var playerTelem = receiver.GetPlayerTelemetry();
+
+            sb.Append("[Session Data]\n");
+
+            if (raceInfo == null || playerState == null)
+            {
+                sb.Append("Active=false\n");
+                return sb.ToString();
+            }
+
+            sb.Append("Active=true\n");
+            sb.AppendFormat("Paused={0}\n", raceInfo.State == UDPRaceSessionState.Active ? "false" : "true");
+            
+            string sessionType = raceInfo.Session.ToLower();
+            if (sessionType.Contains("race"))
+                sb.Append("Session=Race\n");
+            else if (sessionType.Contains("qual"))
+                sb.Append("Session=Qualification\n");
+            else if (sessionType.Contains("practice"))
+                sb.Append("Session=Practice\n");
+            else
+                sb.Append("Session=Other\n");
+
+            sb.AppendFormat("Car={0}\n", NormalizeName(playerState.VehicleName));
+            sb.AppendFormat("Track={0}-{1}\n", NormalizeName(raceInfo.Track), NormalizeName(raceInfo.Layout));
+
+            if (playerTelem != null)
+                sb.AppendFormat("FuelAmount={0}\n", F(playerTelem.Constant.FuelCapacity));
+
+            sb.AppendFormat("SessionFormat={0}\n", raceInfo.IsLaps ? "Laps" : "Time");
+            sb.AppendFormat("SessionTimeRemaining={0}\n", I(raceInfo.Duration * 60));
+            sb.AppendFormat("SessionLapsRemaining={0}\n", 0);
+
+            sb.Append("[Car Data]\n");
+            sb.Append("MAP=n/a\n");
+            sb.Append("TC=n/a\n");
+            sb.Append("ABS=n/a\n");
+            sb.Append("BodyworkDamage=0,0,0,0,0\n");
+            sb.Append("SuspensionDamage=0,0,0,0\n");
+            sb.Append("EngineDamage=0\n");
+
+            if (playerTelem != null)
+            {
+                sb.AppendFormat("FuelRemaining={0}\n", F(playerTelem.Drivetrain.FuelRemaining));
+
+                if (playerTelem.Wheels.Count >= 4)
+                {
+                    var w = playerTelem.Wheels;
+                    sb.AppendFormat("TyreTemperature={0},{1},{2},{3}\n",
+                        F(w[0].TreadTemp[1]), F(w[1].TreadTemp[1]), F(w[2].TreadTemp[1]), F(w[3].TreadTemp[1]));
+                    
+                    sb.AppendFormat("TyreInnerTemperature={0},{1},{2},{3}\n",
+                        F(w[0].TreadTemp[0]), F(w[1].TreadTemp[2]), F(w[2].TreadTemp[0]), F(w[3].TreadTemp[2]));
+                    
+                    sb.AppendFormat("TyreMiddleTemperature={0},{1},{2},{3}\n",
+                        F(w[0].TreadTemp[1]), F(w[1].TreadTemp[1]), F(w[2].TreadTemp[1]), F(w[3].TreadTemp[1]));
+                    
+                    sb.AppendFormat("TyreOuterTemperature={0},{1},{2},{3}\n",
+                        F(w[0].TreadTemp[2]), F(w[1].TreadTemp[0]), F(w[2].TreadTemp[2]), F(w[3].TreadTemp[0]));
+                    
+                    sb.AppendFormat("TyrePressure={0},{1},{2},{3}\n",
+                        F(w[0].Pressure), F(w[1].Pressure), F(w[2].Pressure), F(w[3].Pressure));
+                    
+                    sb.Append("TyreWear=0,0,0,0\n");
+                    
+                    sb.AppendFormat("BrakeTemperature={0},{1},{2},{3}\n",
+                        F(w[0].BrakeTemp), F(w[1].BrakeTemp), F(w[2].BrakeTemp), F(w[3].BrakeTemp));
+                }
+
+                sb.Append("BrakeWear=0,0,0,0\n");
+
+                if (playerTelem.Drivetrain.EngineCoolantTemperature > 0)
+                    sb.AppendFormat("WaterTemperature={0}\n", F(playerTelem.Drivetrain.EngineCoolantTemperature));
+
+                if (playerTelem.Drivetrain.EngineOilTemperature > 0)
+                    sb.AppendFormat("OilTemperature={0}\n", F(playerTelem.Drivetrain.EngineOilTemperature));
+            }
+
+            sb.Append("[Stint Data]\n");
+            ParseDriverName(playerState.DriverName, out string forename, out string surname, out string nickname);
+            sb.AppendFormat("DriverForname={0}\n", forename);
+            sb.AppendFormat("DriverSurname={0}\n", surname);
+            sb.AppendFormat("DriverNickname={0}\n", nickname);
+            sb.AppendFormat("Position={0}\n", playerState.RacePos);
+            sb.Append("LapValid=true\n");
+            sb.AppendFormat("LapLastTime={0}\n", I(playerState.BestLapTime * 1000));
+            sb.AppendFormat("LapBestTime={0}\n", I(playerState.BestLapTime * 1000));
+            sb.AppendFormat("Sector={0}\n", playerState.CurrentSector + 1);
+            sb.AppendFormat("Laps={0}\n", playerState.CurrentLap);
+            sb.AppendFormat("StintTimeRemaining={0}\n", I(raceInfo.Duration * 60));
+            sb.AppendFormat("DriverTimeRemaining={0}\n", I(raceInfo.Duration * 60));
+            sb.AppendFormat("InPit={0}\n", playerState.InPits ? "true" : "false");
+            sb.AppendFormat("InPitLane={0}\n", playerState.InPits ? "true" : "false");
+
+            sb.Append("[Track Data]\n");
+            sb.AppendFormat("Length={0}\n", F(raceInfo.LayoutLength));
+            sb.AppendFormat("Temperature={0}\n", F(raceInfo.TrackTemperature));
+            sb.Append("Grip=Optimum\n");
+
+            sb.Append("[Weather Data]\n");
+            sb.AppendFormat("Temperature={0}\n", F(raceInfo.AmbientTemperature));
+            sb.AppendFormat("Weather={0}\n", raceInfo.Weather);
+            sb.AppendFormat("Weather10Min={0}\n", raceInfo.Weather);
+            sb.AppendFormat("Weather30Min={0}\n", raceInfo.Weather);
+
+            return sb.ToString();
+        }
+
+        private string GenerateStandings()
+        {
+            var sb = new StringBuilder();
+            var raceInfo = receiver.GetRaceInfo();
+            var participants = receiver.GetAllParticipantStates();
+
+            sb.Append("[Position Data]\n");
+
+            if (raceInfo == null || participants.Count == 0)
+            {
+                sb.Append("Active=false\n");
+                sb.Append("Car.Count=0\n");
+                sb.Append("Driver.Car=0\n");
+                return sb.ToString();
+            }
+
+            participants.Sort((a, b) => a.RacePos.CompareTo(b.RacePos));
+
+            int playerCar = 0;
+            for (int i = 0; i < participants.Count; i++)
+            {
+                if (participants[i].IsPlayer)
+                {
+                    playerCar = i + 1;
+                    break;
+                }
+            }
+
+            sb.AppendFormat("Driver.Car={0}\n", playerCar);
+
+            for (int i = 0; i < participants.Count; i++)
+            {
+                var p = participants[i];
+                int carNum = i + 1;
+
+                sb.AppendFormat("Car.{0}.Nr={1}\n", carNum, carNum);
+                sb.AppendFormat("Car.{0}.ID={1}\n", carNum, carNum);
+                sb.AppendFormat("Car.{0}.Class={1}\n", carNum, p.VehicleClass);
+                sb.AppendFormat("Car.{0}.Position={1}\n", carNum, p.RacePos);
+                sb.AppendFormat("Car.{0}.Laps={1}\n", carNum, p.CurrentLap);
+                sb.AppendFormat("Car.{0}.Lap.Running={1}\n", carNum, F(p.LapProgress));
+                sb.AppendFormat("Car.{0}.Lap.Running.Valid=true\n", carNum);
+                sb.AppendFormat("Car.{0}.Time={1}\n", carNum, I(p.BestLapTime * 1000));
+
+                if (p.BestSectorTimes.Count >= 3)
+                {
+                    sb.AppendFormat("Car.{0}.Time.Sectors={1},{2},{3}\n", carNum,
+                        I(p.BestSectorTimes[0] * 1000),
+                        I(p.BestSectorTimes[1] * 1000),
+                        I(p.BestSectorTimes[2] * 1000));
+                }
+
+                sb.AppendFormat("Car.{0}.Car={1}\n", carNum, NormalizeName(p.VehicleName));
+
+                ParseDriverName(p.DriverName, out string forename, out string surname, out string nickname);
+                sb.AppendFormat("Car.{0}.Driver.Forname={1}\n", carNum, forename);
+                sb.AppendFormat("Car.{0}.Driver.Surname={1}\n", carNum, surname);
+                sb.AppendFormat("Car.{0}.Driver.Nickname={1}\n", carNum, nickname);
+                sb.AppendFormat("Car.{0}.InPitLane={1}\n", carNum, p.InPits ? "true" : "false");
+                sb.AppendFormat("Car.{0}.InPit={1}\n", carNum, p.InPits ? "true" : "false");
+            }
+
+            sb.AppendFormat("Car.Count={0}\n", participants.Count);
+
+            return sb.ToString();
+        }
+
+        private string NormalizeName(string name)
+        {
+            return name.Replace("/", "").Replace(":", "").Replace("*", "")
+                       .Replace("?", "").Replace("<", "").Replace(">", "")
+                       .Replace("|", "");
+        }
+
+        private void ParseDriverName(string fullName, out string forename, out string surname, out string nickname)
+        {
+            if (string.IsNullOrEmpty(fullName))
+            {
+                forename = "";
+                surname = "";
+                nickname = "";
+                return;
+            }
+
+            string[] parts = fullName.Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0)
+            {
+                forename = "";
+                surname = "";
+                nickname = "";
+            }
+            else if (parts.Length == 1)
+            {
+                forename = parts[0];
+                surname = "";
+                nickname = parts[0].Length > 0 ? parts[0].Substring(0, 1) : "";
+            }
+            else
+            {
+                forename = parts[0];
+                surname = parts[parts.Length - 1];
+                nickname = forename.Substring(0, 1) + surname.Substring(0, 1);
+            }
+        }
+
+        private string F(float value)
+        {
+            return value.ToString("F2", enUS);
+        }
+
+        private string I(float value)
+        {
+            return ((int)value).ToString(enUS);
+        }
+
+        private string I(int value)
+        {
+            return value.ToString(enUS);
+        }
+    }
+}

--- a/Sources/Special/PMR UDP Connector/PMR UDP Connector/PMRUDPProtocol.cs
+++ b/Sources/Special/PMR UDP Connector/PMR UDP Connector/PMRUDPProtocol.cs
@@ -1,0 +1,484 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PMR_UDP_Connector
+{
+    public enum UDPPacketType : byte
+    {
+        RaceInfo = 0,
+        ParticipantRaceState = 1,
+        ParticipantVehicleTelemetry = 2,
+        SessionStopped = 3
+    }
+
+    public enum UDPRaceSessionState : byte
+    {
+        Inactive = 0,
+        Active = 1,
+        Complete = 2
+    }
+
+    public class UDPRaceInfo
+    {
+        public ushort PacketVersion;
+        public string Track = "";
+        public string Layout = "";
+        public string Season = "";
+        public string Weather = "";
+        public string Session = "";
+        public string GameMode = "";
+        public float LayoutLength;
+        public float Duration;
+        public float Overtime;
+        public float AmbientTemperature;
+        public float TrackTemperature;
+        public bool IsLaps;
+        public UDPRaceSessionState State;
+        public byte NumParticipants;
+
+        public static UDPRaceInfo Decode(byte[] data, ref int offset)
+        {
+            var info = new UDPRaceInfo();
+            info.PacketVersion = BitConverter.ToUInt16(data, offset); offset += 2;
+            info.Track = ReadString(data, ref offset);
+            info.Layout = ReadString(data, ref offset);
+            info.Season = ReadString(data, ref offset);
+            info.Weather = ReadString(data, ref offset);
+            info.Session = ReadString(data, ref offset);
+            info.GameMode = ReadString(data, ref offset);
+            info.LayoutLength = BitConverter.ToSingle(data, offset); offset += 4;
+            info.Duration = BitConverter.ToSingle(data, offset); offset += 4;
+            info.Overtime = BitConverter.ToSingle(data, offset); offset += 4;
+            info.AmbientTemperature = BitConverter.ToSingle(data, offset); offset += 4;
+            info.TrackTemperature = BitConverter.ToSingle(data, offset); offset += 4;
+            info.IsLaps = data[offset++] != 0;
+            info.State = (UDPRaceSessionState)data[offset++];
+            info.NumParticipants = data[offset++];
+            return info;
+        }
+
+        private static string ReadString(byte[] data, ref int offset)
+        {
+            byte len = data[offset++];
+            if (len == 0) return "";
+            string result = Encoding.UTF8.GetString(data, offset, len);
+            offset += len;
+            return result;
+        }
+    }
+
+    public class UDPParticipantRaceState
+    {
+        public ushort PacketVersion;
+        public int VehicleId;
+        public bool IsPlayer;
+        public string VehicleName = "";
+        public string DriverName = "";
+        public string LiveryId = "";
+        public string VehicleClass = "";
+        public int RacePos;
+        public int CurrentLap;
+        public float CurrentLapTime;
+        public float BestLapTime;
+        public float LapProgress;
+        public int CurrentSector;
+        public List<float> CurrentSectorTimes = new List<float>();
+        public List<float> BestSectorTimes = new List<float>();
+        public bool InPits;
+        public bool SessionFinished;
+        public bool DQ;
+        public uint Flags;
+
+        public static UDPParticipantRaceState Decode(byte[] data, ref int offset)
+        {
+            var state = new UDPParticipantRaceState();
+            state.PacketVersion = BitConverter.ToUInt16(data, offset); offset += 2;
+            state.VehicleId = BitConverter.ToInt32(data, offset); offset += 4;
+            state.IsPlayer = data[offset++] != 0;
+            state.VehicleName = ReadString(data, ref offset);
+            state.DriverName = ReadString(data, ref offset);
+            state.LiveryId = ReadString(data, ref offset);
+            state.VehicleClass = ReadString(data, ref offset);
+            state.RacePos = BitConverter.ToInt32(data, offset); offset += 4;
+            state.CurrentLap = BitConverter.ToInt32(data, offset); offset += 4;
+            state.CurrentLapTime = BitConverter.ToSingle(data, offset); offset += 4;
+            state.BestLapTime = BitConverter.ToSingle(data, offset); offset += 4;
+            state.LapProgress = BitConverter.ToSingle(data, offset); offset += 4;
+            state.CurrentSector = BitConverter.ToInt32(data, offset); offset += 4;
+            
+            byte numSectors = data[offset++];
+            for (int i = 0; i < numSectors; i++)
+            {
+                state.CurrentSectorTimes.Add(BitConverter.ToSingle(data, offset));
+                offset += 4;
+            }
+            
+            numSectors = data[offset++];
+            for (int i = 0; i < numSectors; i++)
+            {
+                state.BestSectorTimes.Add(BitConverter.ToSingle(data, offset));
+                offset += 4;
+            }
+            
+            state.InPits = data[offset++] != 0;
+            state.SessionFinished = data[offset++] != 0;
+            state.DQ = data[offset++] != 0;
+            state.Flags = BitConverter.ToUInt32(data, offset); offset += 4;
+            return state;
+        }
+
+        private static string ReadString(byte[] data, ref int offset)
+        {
+            byte len = data[offset++];
+            if (len == 0) return "";
+            string result = Encoding.UTF8.GetString(data, offset, len);
+            offset += len;
+            return result;
+        }
+    }
+
+    public class UDPVehicleTelemetry
+    {
+        public ushort PacketVersion;
+        public int VehicleId;
+        public List<WheelData> Wheels = new List<WheelData>();
+        public ChassisData Chassis = new ChassisData();
+        public DrivetrainData Drivetrain = new DrivetrainData();
+        public SuspensionData Suspension = new SuspensionData();
+        public InputData Input = new InputData();
+        public SetupData Setup = new SetupData();
+        public GeneralData General = new GeneralData();
+        public ConstantData Constant = new ConstantData();
+
+        public class WheelData
+        {
+            public int ContactMaterialHash;
+            public float AngularVelocity;
+            public float LinearSpeed;
+            public float[] SlideLS = new float[3];
+            public float[] ForceLS = new float[3];
+            public float[] MomentLS = new float[3];
+            public float ContactRadius;
+            public float Pressure;
+            public float Inclination;
+            public float SlipRatio;
+            public float SlipAngle;
+            public float[] TreadTemp = new float[3];
+            public float CarcassTemp;
+            public float InternalAirTemp;
+            public float WellAirTemp;
+            public float RimTemp;
+            public float BrakeTemp;
+            public float SpringStrain;
+            public float DamperVelocity;
+            public float HubTorque;
+            public float HubPower;
+            public float WheelTorque;
+            public float WheelPower;
+        }
+
+        public class ChassisData
+        {
+            public float[] PosWS = new float[3];
+            public float[] Quat = new float[4];
+            public float[] AngularVelocityWS = new float[3];
+            public float[] AngularVelocityLS = new float[3];
+            public float[] VelocityWS = new float[3];
+            public float[] VelocityLS = new float[3];
+            public float[] AccelerationWS = new float[3];
+            public float[] AccelerationLS = new float[3];
+            public float OverallSpeed;
+            public float ForwardSpeed;
+            public float Sideslip;
+        }
+
+        public class DrivetrainData
+        {
+            public float EngineRPM;
+            public float EngineRevRatio;
+            public float EngineTorque;
+            public float EnginePower;
+            public float EngineLoad;
+            public float EngineTurboRPM;
+            public float EngineTurboBoostPressure;
+            public float FuelRemaining;
+            public float FuelUseRate;
+            public float EngineOilPressure;
+            public float EngineOilTemperature;
+            public float EngineCoolantTemperature;
+            public float ExhaustGasTemperature;
+            public float MotorRPM;
+            public float BatteryRemaining;
+            public float BatteryUseRate;
+            public float TransmissionRPM;
+            public float GearboxInputRPM;
+            public float GearboxOutputRPM;
+            public float GearboxTorque;
+            public float GearboxPower;
+            public float GearboxLoadIn;
+            public float GearboxLoadOut;
+            public float TimeSinceShift;
+            public float EstDrivenSpeed;
+            public float OutputTorque;
+            public float OutputPower;
+            public float OutputEfficiency;
+            public bool StarterActive;
+            public bool EngineRunning;
+            public bool EngineFanRunning;
+            public bool RevLimiterActive;
+            public bool TractionControlActive;
+            public bool SpeedLimiterEnabled;
+            public bool SpeedLimiterActive;
+            public List<GearData> Gears = new List<GearData>();
+        }
+
+        public class GearData
+        {
+            public float UpshiftRPM;
+            public float DownshiftRPM;
+        }
+
+        public class SuspensionData
+        {
+            public List<float> AvgLoads = new List<float>();
+            public float LoadBias;
+        }
+
+        public class InputData
+        {
+            public float Steering;
+            public float Accelerator;
+            public float Brake;
+            public float Clutch;
+            public float Handbrake;
+            public int Gear;
+        }
+
+        public class SetupData
+        {
+            public float BrakeBias;
+            public float FrontAntiRollStiffness;
+            public float RearAntiRollStiffness;
+            public float RegenLimit;
+            public float DeployLimit;
+            public byte ABSLevel;
+            public byte TCSLevel;
+        }
+
+        public class GeneralData
+        {
+            public float[] CenterOfGravity = new float[3];
+            public float SteeringWheelAngle;
+            public float TotalMass;
+            public float DrivenWheelAngVel;
+            public float NonDrivenWheelAngVel;
+            public float EstRollingSpeed;
+            public float EstLinearSpeed;
+            public float TotalBrakeForce;
+            public bool ABSActive;
+        }
+
+        public class ConstantData
+        {
+            public float[] ChassisBBMin = new float[3];
+            public float[] ChassisBBMax = new float[3];
+            public float StarterIdleRPM;
+            public float EngineTorquePeakRPM;
+            public float EnginePowerPeakRPM;
+            public float EngineMaxRPM;
+            public float EngineMaxTorque;
+            public float EngineMaxPower;
+            public float EngineMaxBoost;
+            public float FuelCapacity;
+            public float BatteryCapacity;
+            public float TrackWidthFront;
+            public float TrackWidthRear;
+            public float Wheelbase;
+            public byte NumberOfWheels;
+            public byte NumberOfForwardGears;
+            public byte NumberOfReverseGears;
+            public bool IsHybrid;
+        }
+
+        public static UDPVehicleTelemetry Decode(byte[] data, ref int offset)
+        {
+            var telem = new UDPVehicleTelemetry();
+            telem.PacketVersion = BitConverter.ToUInt16(data, offset); offset += 2;
+            telem.VehicleId = BitConverter.ToInt32(data, offset); offset += 4;
+
+            byte numWheels = data[offset++];
+            for (int i = 0; i < numWheels; i++)
+                telem.Wheels.Add(ReadWheel(data, ref offset));
+
+            ReadChassis(data, ref offset, telem.Chassis);
+            ReadDrivetrain(data, ref offset, telem.Drivetrain);
+            ReadSuspension(data, ref offset, telem.Suspension);
+            ReadInput(data, ref offset, telem.Input);
+            ReadSetup(data, ref offset, telem.Setup);
+            ReadGeneral(data, ref offset, telem.General);
+            ReadConstant(data, ref offset, telem.Constant);
+
+            return telem;
+        }
+
+        private static WheelData ReadWheel(byte[] data, ref int offset)
+        {
+            var wheel = new WheelData();
+            wheel.ContactMaterialHash = BitConverter.ToInt32(data, offset); offset += 4;
+            wheel.AngularVelocity = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.LinearSpeed = BitConverter.ToSingle(data, offset); offset += 4;
+            for (int i = 0; i < 3; i++) { wheel.SlideLS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { wheel.ForceLS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { wheel.MomentLS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            wheel.ContactRadius = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.Pressure = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.Inclination = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.SlipRatio = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.SlipAngle = BitConverter.ToSingle(data, offset); offset += 4;
+            for (int i = 0; i < 3; i++) { wheel.TreadTemp[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            wheel.CarcassTemp = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.InternalAirTemp = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.WellAirTemp = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.RimTemp = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.BrakeTemp = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.SpringStrain = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.DamperVelocity = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.HubTorque = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.HubPower = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.WheelTorque = BitConverter.ToSingle(data, offset); offset += 4;
+            wheel.WheelPower = BitConverter.ToSingle(data, offset); offset += 4;
+            return wheel;
+        }
+
+        private static void ReadChassis(byte[] data, ref int offset, ChassisData chassis)
+        {
+            for (int i = 0; i < 3; i++) { chassis.PosWS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 4; i++) { chassis.Quat[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { chassis.AngularVelocityWS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { chassis.AngularVelocityLS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { chassis.VelocityWS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { chassis.VelocityLS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { chassis.AccelerationWS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { chassis.AccelerationLS[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            chassis.OverallSpeed = BitConverter.ToSingle(data, offset); offset += 4;
+            chassis.ForwardSpeed = BitConverter.ToSingle(data, offset); offset += 4;
+            chassis.Sideslip = BitConverter.ToSingle(data, offset); offset += 4;
+        }
+
+        private static void ReadDrivetrain(byte[] data, ref int offset, DrivetrainData dt)
+        {
+            dt.EngineRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EngineRevRatio = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EngineTorque = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EnginePower = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EngineLoad = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EngineTurboRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EngineTurboBoostPressure = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.FuelRemaining = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.FuelUseRate = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EngineOilPressure = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EngineOilTemperature = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EngineCoolantTemperature = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.ExhaustGasTemperature = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.MotorRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.BatteryRemaining = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.BatteryUseRate = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.TransmissionRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.GearboxInputRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.GearboxOutputRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.GearboxTorque = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.GearboxPower = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.GearboxLoadIn = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.GearboxLoadOut = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.TimeSinceShift = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.EstDrivenSpeed = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.OutputTorque = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.OutputPower = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.OutputEfficiency = BitConverter.ToSingle(data, offset); offset += 4;
+            dt.StarterActive = data[offset++] != 0;
+            dt.EngineRunning = data[offset++] != 0;
+            dt.EngineFanRunning = data[offset++] != 0;
+            dt.RevLimiterActive = data[offset++] != 0;
+            dt.TractionControlActive = data[offset++] != 0;
+            dt.SpeedLimiterEnabled = data[offset++] != 0;
+            dt.SpeedLimiterActive = data[offset++] != 0;
+            
+            byte numGears = data[offset++];
+            for (int i = 0; i < numGears; i++)
+            {
+                var gear = new GearData();
+                gear.UpshiftRPM = BitConverter.ToSingle(data, offset); offset += 4;
+                gear.DownshiftRPM = BitConverter.ToSingle(data, offset); offset += 4;
+                dt.Gears.Add(gear);
+            }
+        }
+
+        private static void ReadSuspension(byte[] data, ref int offset, SuspensionData susp)
+        {
+            byte numLoads = data[offset++];
+            for (int i = 0; i < numLoads; i++)
+            {
+                susp.AvgLoads.Add(BitConverter.ToSingle(data, offset));
+                offset += 4;
+            }
+            susp.LoadBias = BitConverter.ToSingle(data, offset); offset += 4;
+        }
+
+        private static void ReadInput(byte[] data, ref int offset, InputData input)
+        {
+            input.Steering = BitConverter.ToSingle(data, offset); offset += 4;
+            input.Accelerator = BitConverter.ToSingle(data, offset); offset += 4;
+            input.Brake = BitConverter.ToSingle(data, offset); offset += 4;
+            input.Clutch = BitConverter.ToSingle(data, offset); offset += 4;
+            input.Handbrake = BitConverter.ToSingle(data, offset); offset += 4;
+            input.Gear = BitConverter.ToInt32(data, offset); offset += 4;
+        }
+
+        private static void ReadSetup(byte[] data, ref int offset, SetupData setup)
+        {
+            setup.BrakeBias = BitConverter.ToSingle(data, offset); offset += 4;
+            setup.FrontAntiRollStiffness = BitConverter.ToSingle(data, offset); offset += 4;
+            setup.RearAntiRollStiffness = BitConverter.ToSingle(data, offset); offset += 4;
+            setup.RegenLimit = BitConverter.ToSingle(data, offset); offset += 4;
+            setup.DeployLimit = BitConverter.ToSingle(data, offset); offset += 4;
+            setup.ABSLevel = data[offset++];
+            setup.TCSLevel = data[offset++];
+        }
+
+        private static void ReadGeneral(byte[] data, ref int offset, GeneralData gen)
+        {
+            for (int i = 0; i < 3; i++) { gen.CenterOfGravity[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            gen.SteeringWheelAngle = BitConverter.ToSingle(data, offset); offset += 4;
+            gen.TotalMass = BitConverter.ToSingle(data, offset); offset += 4;
+            gen.DrivenWheelAngVel = BitConverter.ToSingle(data, offset); offset += 4;
+            gen.NonDrivenWheelAngVel = BitConverter.ToSingle(data, offset); offset += 4;
+            gen.EstRollingSpeed = BitConverter.ToSingle(data, offset); offset += 4;
+            gen.EstLinearSpeed = BitConverter.ToSingle(data, offset); offset += 4;
+            gen.TotalBrakeForce = BitConverter.ToSingle(data, offset); offset += 4;
+            gen.ABSActive = data[offset++] != 0;
+        }
+
+        private static void ReadConstant(byte[] data, ref int offset, ConstantData constant)
+        {
+            for (int i = 0; i < 3; i++) { constant.ChassisBBMin[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            for (int i = 0; i < 3; i++) { constant.ChassisBBMax[i] = BitConverter.ToSingle(data, offset); offset += 4; }
+            constant.StarterIdleRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.EngineTorquePeakRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.EnginePowerPeakRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.EngineMaxRPM = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.EngineMaxTorque = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.EngineMaxPower = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.EngineMaxBoost = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.FuelCapacity = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.BatteryCapacity = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.TrackWidthFront = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.TrackWidthRear = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.Wheelbase = BitConverter.ToSingle(data, offset); offset += 4;
+            constant.NumberOfWheels = data[offset++];
+            constant.NumberOfForwardGears = data[offset++];
+            constant.NumberOfReverseGears = data[offset++];
+            constant.IsHybrid = data[offset++] != 0;
+        }
+    }
+}

--- a/Sources/Special/PMR UDP Connector/PMR UDP Connector/PMRUDPReceiver.cs
+++ b/Sources/Special/PMR UDP Connector/PMR UDP Connector/PMRUDPReceiver.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+
+namespace PMR_UDP_Connector
+{
+    public class PMRUDPReceiver
+    {
+        private UdpClient udpClient;
+        private Thread receiveThread;
+        private bool isRunning;
+        private readonly int port;
+        private readonly string multicastGroup;
+        private readonly bool useMulticast;
+
+        private UDPRaceInfo raceInfo;
+        private Dictionary<int, UDPParticipantRaceState> participantStates = new Dictionary<int, UDPParticipantRaceState>();
+        private Dictionary<int, UDPVehicleTelemetry> participantTelemetry = new Dictionary<int, UDPVehicleTelemetry>();
+        private int playerVehicleId = -1;
+        private readonly object dataLock = new object();
+
+        public PMRUDPReceiver(int port = 7576, string multicastGroup = "224.0.0.150", bool useMulticast = true)
+        {
+            this.port = port;
+            this.multicastGroup = multicastGroup;
+            this.useMulticast = useMulticast;
+        }
+
+        public bool Start()
+        {
+            try
+            {
+                if (useMulticast)
+                {
+                    udpClient = new UdpClient(port);
+                    udpClient.JoinMulticastGroup(IPAddress.Parse(multicastGroup));
+                }
+                else
+                {
+                    udpClient = new UdpClient(new IPEndPoint(IPAddress.Any, port));
+                }
+
+                isRunning = true;
+                receiveThread = new Thread(ReceiveData);
+                receiveThread.IsBackground = true;
+                receiveThread.Start();
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public void Stop()
+        {
+            isRunning = false;
+            udpClient?.Close();
+            receiveThread?.Join(1000);
+        }
+
+        private void ReceiveData()
+        {
+            IPEndPoint remoteEndPoint = new IPEndPoint(IPAddress.Any, 0);
+
+            while (isRunning)
+            {
+                try
+                {
+                    byte[] data = udpClient.Receive(ref remoteEndPoint);
+                    ProcessPacket(data);
+                }
+                catch (SocketException)
+                {
+                    break;
+                }
+                catch
+                {
+                    // Ignore malformed packets
+                }
+            }
+        }
+
+        private void ProcessPacket(byte[] data)
+        {
+            if (data.Length < 1) return;
+
+            UDPPacketType packetType = (UDPPacketType)data[0];
+            int offset = 1;
+
+            lock (dataLock)
+            {
+                switch (packetType)
+                {
+                    case UDPPacketType.RaceInfo:
+                        raceInfo = UDPRaceInfo.Decode(data, ref offset);
+                        break;
+
+                    case UDPPacketType.ParticipantRaceState:
+                        var state = UDPParticipantRaceState.Decode(data, ref offset);
+                        participantStates[state.VehicleId] = state;
+                        if (state.IsPlayer)
+                            playerVehicleId = state.VehicleId;
+                        break;
+
+                    case UDPPacketType.ParticipantVehicleTelemetry:
+                        var telem = UDPVehicleTelemetry.Decode(data, ref offset);
+                        participantTelemetry[telem.VehicleId] = telem;
+                        break;
+
+                    case UDPPacketType.SessionStopped:
+                        ClearSessionData();
+                        break;
+                }
+            }
+        }
+
+        private void ClearSessionData()
+        {
+            raceInfo = null;
+            participantStates.Clear();
+            participantTelemetry.Clear();
+            playerVehicleId = -1;
+        }
+
+        public UDPRaceInfo GetRaceInfo()
+        {
+            lock (dataLock)
+            {
+                return raceInfo;
+            }
+        }
+
+        public UDPParticipantRaceState GetPlayerState()
+        {
+            lock (dataLock)
+            {
+                if (playerVehicleId >= 0 && participantStates.ContainsKey(playerVehicleId))
+                    return participantStates[playerVehicleId];
+                return null;
+            }
+        }
+
+        public UDPVehicleTelemetry GetPlayerTelemetry()
+        {
+            lock (dataLock)
+            {
+                if (playerVehicleId >= 0 && participantTelemetry.ContainsKey(playerVehicleId))
+                    return participantTelemetry[playerVehicleId];
+                return null;
+            }
+        }
+
+        public List<UDPParticipantRaceState> GetAllParticipantStates()
+        {
+            lock (dataLock)
+            {
+                return new List<UDPParticipantRaceState>(participantStates.Values);
+            }
+        }
+
+        public bool IsActive()
+        {
+            lock (dataLock)
+            {
+                return raceInfo != null && raceInfo.State == UDPRaceSessionState.Active;
+            }
+        }
+    }
+}

--- a/Sources/Special/PMR UDP Connector/PMR UDP Connector/Properties/AssemblyInfo.cs
+++ b/Sources/Special/PMR UDP Connector/PMR UDP Connector/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("PMR UDP Connector")]
+[assembly: AssemblyDescription("Project Motor Racing UDP Telemetry Connector")]
+[assembly: AssemblyCompany("Simulator Controller")]
+[assembly: AssemblyProduct("PMR UDP Connector")]
+[assembly: AssemblyCopyright("Copyright © 2025")]
+[assembly: ComVisible(false)]
+[assembly: Guid("b8f2a9d3-7e4c-4d1b-9a2f-8c5d6e7f8a9b")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Sources/Special/PMR UDP Provider/PMR UDP Provider/PMR UDP Provider.csproj
+++ b/Sources/Special/PMR UDP Provider/PMR UDP Provider/PMR UDP Provider.csproj
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C3E5F8A2-9D4B-4E1C-8F3A-7B6C9D8E5F4A}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PMR_UDP_Provider</RootNamespace>
+    <AssemblyName>PMR UDP Provider</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>..\..\..\..\Binaries\Providers\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\..\..\..\Binaries\Providers\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\PMR UDP Connector\PMR UDP Connector\PMR UDP Connector.csproj">
+      <Project>{B8F2A9D3-7E4C-4D1B-9A2F-8C5D6E7F8A9B}</Project>
+      <Name>PMR UDP Connector</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Sources/Special/PMR UDP Provider/PMR UDP Provider/Program.cs
+++ b/Sources/Special/PMR UDP Provider/PMR UDP Provider/Program.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using PMR_UDP_Connector;
+
+namespace PMR_UDP_Provider
+{
+    class Program
+    {
+        [STAThread]
+        static void Main(string[] args)
+        {
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+            
+            string request = args.Length > 0 ? args[0] : "";
+            PMRUDPConnector connector = new PMRUDPConnector();
+            
+            if (!connector.Open())
+            {
+                Console.WriteLine("[Session Data]");
+                Console.WriteLine("Active=false");
+                return;
+            }
+
+            try
+            {
+                string output = connector.Call(request);
+                Console.Write(output);
+            }
+            finally
+            {
+                connector.Close();
+            }
+        }
+    }
+}

--- a/Sources/Special/PMR UDP Provider/PMR UDP Provider/Properties/AssemblyInfo.cs
+++ b/Sources/Special/PMR UDP Provider/PMR UDP Provider/Properties/AssemblyInfo.cs
@@ -1,0 +1,12 @@
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("PMR UDP Provider")]
+[assembly: AssemblyDescription("Project Motor Racing UDP Telemetry Provider")]
+[assembly: AssemblyCompany("Simulator Controller")]
+[assembly: AssemblyProduct("PMR UDP Provider")]
+[assembly: AssemblyCopyright("Copyright © 2025")]
+[assembly: ComVisible(false)]
+[assembly: Guid("c3e5f8a2-9d4b-4e1c-8f3a-7b6c9d8e5f4a")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]


### PR DESCRIPTION
- PMR UDP Connector.dll: .NET 4.8 CLR connector for Project Motor Racing UDP telemetry
- PMR UDP Provider.exe: Console wrapper for command-line testing and AHK integration
- Complete UDP protocol implementation (RaceInfo, ParticipantRaceState, VehicleTelemetry)
- Background UDP receiver on port 7576 with multicast support (224.0.0.150)
- Thread-safe data storage with automatic player vehicle detection
- INI format output matching Simulator Controller expectations

Ready for AHK integration layer (Plugin + Provider files).